### PR TITLE
Fix Geohasher.decode edge-case handling.

### DIFF
--- a/src/main/java/com/javadocmd/simplelatlng/Geohasher.java
+++ b/src/main/java/com/javadocmd/simplelatlng/Geohasher.java
@@ -48,7 +48,7 @@ public class Geohasher {
 	 * 
 	 * <pre>
 	 * LATITUDE_ERROR = 90.0 / (2 ^ (BITS + 1))
-	 *LONGITUDE_ERROR = 180.0 / (2 ^ (BITS + 1))
+	 * LONGITUDE_ERROR = 180.0 / (2 ^ (BITS + 1))
 	 * </pre>
 	 */
 	public static final int PRECISION = 12;
@@ -86,9 +86,16 @@ public class Geohasher {
 	 * @param hash the geohash string of any precision, although LatLng will still
 	 *             not become <em>more</em> precise than its settings.
 	 * @return the decoded point.
+	 * @throws IllegalArgumentException on null or empty strings, or strings which
+	 *                                  contain invalid geohash characters:
+	 *                                  [0-9bcdefghjkmnpqrstuvwxyz]
 	 */
 	public static LatLng decode(String hash) {
-		BitSet[] b = deInterleave(hashToBits(hash));
+		if (hash == null || hash.isEmpty()) {
+			throw new IllegalArgumentException("Geohash string cannot be empty or null.");
+		}
+		int n = Math.min(hash.length(), PRECISION); // truncate hashes that are longer than supported
+		BitSet[] b = deInterleave(hashToBits(hash.substring(0, n).toLowerCase()));
 		double lat = bitsToDouble(b[1], LAT_BIT_VALUES);
 		double lng = bitsToDouble(b[0], LNG_BIT_VALUES);
 		return new LatLng(lat, lng);
@@ -104,10 +111,9 @@ public class Geohasher {
 		try {
 			BitSet bits = new BitStore();
 
-			char[] chars = hash.toLowerCase().toCharArray();
-			int offset = (chars.length - 1) * 5;
-			for (int i = 0; i < chars.length; i++) {
-				int value = HASH_CHARS_MAP.get(chars[i]).intValue();
+			int offset = (hash.length() - 1) * 5;
+			for (int i = 0; i < hash.length(); i++) {
+				int value = HASH_CHARS_MAP.get(hash.charAt(i)).intValue();
 				for (int x = 0; x < 5; x++) {
 					bits.set(offset + x, (value & 0x1) == 0x1);
 					value >>= 1;

--- a/src/test/java/com/javadocmd/simplelatlng/GeohasherTest.java
+++ b/src/test/java/com/javadocmd/simplelatlng/GeohasherTest.java
@@ -97,6 +97,31 @@ public class GeohasherTest {
 	}
 
 	@Test
+	public void testDecode7() {
+		// Test long inputs.
+		LatLng p = new LatLng(1, 1);
+		assertEquals(p, Geohasher.decode("s00twy01mtw0bbbbbbbbbbbbbbbb"));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testDecode8() {
+		// Test empty input.
+		Geohasher.decode("");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testDecode9() {
+		// Test null input.
+		Geohasher.decode(null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testDecode10() {
+		// Test invalid characters input.
+		Geohasher.decode("this input is invalid");
+	}
+
+	@Test
 	public void testHashToBits() {
 		BitStore bits = (BitStore) hashToBits("ezs42");
 		assertEquals(25, bits.size());


### PR DESCRIPTION
IllegalArgumentsException thrown for empty, null, or invalid chars.
Hashes longer than 12 chars are silently truncated on decode.